### PR TITLE
Fix the centering issue of pymakeplots

### DIFF
--- a/pymakeplots/pymakeplots.py
+++ b/pymakeplots/pymakeplots.py
@@ -354,9 +354,13 @@ class pymakeplots:
         
         
         
-        _centskycoord=self.spectralcube.wcs.celestial.pixel_to_world(self.xcoord.size//2,self.ycoord.size//2).transform_to('icrs')
-        self.obj_ra=_centskycoord.ra.value
-        self.obj_dec=_centskycoord.dec.value
+        self.centskycoord=self.spectralcube.wcs.celestial.pixel_to_world(self.xcoord.size//2,self.ycoord.size//2).transform_to('icrs')
+        self.x_skycent=self.centskycoord.ra.value
+        self.y_skycent=self.centskycoord.dec.value
+        if self.obj_ra == None:
+            self.obj_ra=self.x_skycent
+        if self.obj_dec == None:
+            self.obj_dec=self.y_skycent
         
             
             
@@ -388,8 +392,8 @@ class pymakeplots:
         #
         #
         # breakpoint()
-        self.xc=self.xcoord_trim*(-1) 
-        self.yc=self.ycoord_trim 
+        self.xc=(self.xcoord_trim+(self.x_skycent-self.obj_ra)*3600)  *(-1) 
+        self.yc=self.ycoord_trim+(self.y_skycent-self.obj_dec)*3600
         
 
         
@@ -572,8 +576,8 @@ class pymakeplots:
                 self.imagesize=[self.imagesize,self.imagesize]
             
 
-            wx,=np.where((np.abs(self.xcoord) <= self.imagesize[0]))
-            wy,=np.where((np.abs(self.ycoord) <= self.imagesize[1]))
+            wx,=np.where((np.abs(self.xcoord+(self.x_skycent-self.obj_ra)*3600) <= self.imagesize[0]))
+            wy,=np.where((np.abs(self.ycoord+(self.y_skycent-self.obj_dec)*3600) <= self.imagesize[1]))
             self.spatial_trim=[np.min(wx),np.max(wx),np.min(wy),np.max(wy)]        
         
         if self.spatial_trim == None:

--- a/pymakeplots/pymakeplots.py
+++ b/pymakeplots/pymakeplots.py
@@ -303,8 +303,8 @@ class pymakeplots:
 
         cd1=self.spectralcube.wcs.pixel_scale_matrix[0,0]*3600
         cd2=self.spectralcube.wcs.pixel_scale_matrix[1,1]*3600
-        x1=((np.arange(0,hdr['NAXIS1'])-(hdr['NAXIS1']//2))*cd1)# + hdr['CRVAL1']
-        y1=((np.arange(0,hdr['NAXIS2'])-(hdr['NAXIS1']//2))*cd2)# + hdr['CRVAL2']
+        x1=((np.arange(1,hdr['NAXIS1']+1)-(hdr['NAXIS1']//2))*cd1)# + hdr['CRVAL1']
+        y1=((np.arange(1,hdr['NAXIS2']+1)-(hdr['NAXIS1']//2))*cd2)# + hdr['CRVAL2']
 
         v1=self.spectralcube.spectral_axis.value
 


### PR DESCRIPTION
Hi Tim,

I have implemented some changes that should fix the centering issue. Most of the changes are similar to your spherical coordinate corrections to KinMS. Another issue is the difference between the pixel indexing in fits files and the array indexing in Python. For instance, in wcs.celestial.pixel_to_world, the pixel with coordinate 100 is the 100th pixel, but when the image is a Numpy array, the 100th array element is the 101st pixel. This causes a one-pixel offset. These changes fixed the centering issue in my plots, but I haven't tested the new code thoroughly. Can you check if my changes make sense and merge nicely with the rest of the code? Thanks a lot!

Best regards,
Hengyue Zhang